### PR TITLE
custom port number for connection and read double

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "nuxt.isNuxtApp": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "nuxt.isNuxtApp": false
-}

--- a/src/field.rs
+++ b/src/field.rs
@@ -117,17 +117,17 @@ pub struct Double {
     /// offset example 8.1
     /// left side is index within the block
     /// right side is the bit position only used for bool, zero for all other types
-    offset: f32,
+    offset: f64,
     value: f64,
 }
 
 impl Double {
-    pub fn new(data_block: i32, offset: f32, mut bytes: Vec<u8>) -> Result<Double, Error> {
+    pub fn new(data_block: i32, offset: f64, mut bytes: Vec<u8>) -> Result<Double, Error> {
         let len = bytes.len();
-        if bytes.len() != Float::size() as usize {
+        if bytes.len() != Double::size() as usize {
             return Err(Error::TryFrom(
                 bytes,
-                format!("Float.new: expected buf size {} got {}", Float::size(), len),
+                format!("Double.new: expected buf size {} got {}", Double::size(), len),
             ));
         }
 
@@ -136,7 +136,7 @@ impl Double {
             return Err(Error::TryFrom(
                 bytes,
                 format!(
-                    "Float.new: float should not have a bit offset got {}",
+                    "Double.new: double should not have a bit offset got {}",
                     bit_offset
                 ),
             ));

--- a/src/field.rs
+++ b/src/field.rs
@@ -111,6 +111,74 @@ impl Field for Float {
     }
 }
 
+#[derive(Debug)]
+pub struct Double {
+    data_block: i32,
+    /// offset example 8.1
+    /// left side is index within the block
+    /// right side is the bit position only used for bool, zero for all other types
+    offset: f32,
+    value: f64,
+}
+
+impl Double {
+    pub fn new(data_block: i32, offset: f32, mut bytes: Vec<u8>) -> Result<Double, Error> {
+        let len = bytes.len();
+        if bytes.len() != Float::size() as usize {
+            return Err(Error::TryFrom(
+                bytes,
+                format!("Float.new: expected buf size {} got {}", Float::size(), len),
+            ));
+        }
+
+        let bit_offset = ((offset * 10.0) as usize % 10) as u8;
+        if bit_offset != 0 {
+            return Err(Error::TryFrom(
+                bytes,
+                format!(
+                    "Float.new: float should not have a bit offset got {}",
+                    bit_offset
+                ),
+            ));
+        }
+
+        Ok(Double {
+            data_block,
+            offset,
+            value: BigEndian::read_f64(bytes.as_mut_slice()),
+        })
+    }
+
+    pub fn size() -> i32 {
+        8
+    }
+
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    pub fn set_value(&mut self, v: f64) {
+        self.value = v
+    }
+}
+
+impl Field for Double {
+    fn data_block(&self) -> i32 {
+        self.data_block
+    }
+
+    fn offset(&self) -> i32 {
+        self.offset as i32
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = vec![0u8; Double::size() as usize];
+        BigEndian::write_f64(buf.as_mut_slice(), self.value);
+        return buf;
+    }
+}
+
+
 /// Bool represents a single bit in a byte from `Area::DataBausteine`
 #[derive(Debug)]
 pub struct Bool {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -23,7 +23,7 @@ pub const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 pub const MAX_LENGTH: usize = 2084;
 //messages
 const PDU_SIZE_REQUESTED: i32 = 480;
-const ISO_TCP: i32 = 102; //default isotcp port
+pub const ISO_TCP: i32 = 102; //default isotcp port
 const ISO_HEADER_SIZE: i32 = 7; // TPKT+COTP Header Size
 const MIN_PDU_SIZE: i32 = 16;
 
@@ -55,12 +55,17 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn new(address: IpAddr, rack: u16, slot: u16, conn_type: Connection) -> Options {
+    pub fn new(address: IpAddr, port: i32, rack: u16, slot: u16, conn_type: Connection) -> Options {
+        let port = match port {
+            0 => ISO_TCP,
+            _ => port
+        };
+
         Options {
             connection_timeout: None,
             read_timeout: Duration::new(0, 0),
             write_timeout: Duration::new(0, 0),
-            address: format!("{}:{}", address.to_string(), ISO_TCP.to_string()), //ip:102,
+            address: format!("{}:{}", address.to_string(), port.to_string()), //ip:102,
             conn_type,
             rack,
             slot,


### PR DESCRIPTION
Hi, I have had the problem to connect to a remote S7 specifying a different port number, so I modifyed the library to add the port number as parameter after the ip address. Giving 0 results in the default ISO_TPC port 102.

I also added the possibility to read doubles (double precision floats)

And "big big thanks" for your library again